### PR TITLE
Adjust maze_c tests to run on single thread

### DIFF
--- a/.github/workflows/build-and-test-components-multi-os.yml
+++ b/.github/workflows/build-and-test-components-multi-os.yml
@@ -152,7 +152,7 @@ jobs:
         cargo test --locked -p auth
         cargo test --locked -p data_model
         cargo test --locked -p maze --features generation
-        cargo test --locked -p maze_c
+        cargo test --locked -p maze_c -- --test-threads=1
         cargo test --locked -p maze_console -- --test-threads=1
         cargo test --locked -p storage -- --test-threads=1
         cargo test --locked -p maze_wasm

--- a/src/rust/README.md
+++ b/src/rust/README.md
@@ -73,7 +73,7 @@ To test all `Rust` crates:
 ```
 cd src/rust
 cargo test -p maze --features generation
-cargo test -p maze_c
+cargo test -p maze_c -- --test-threads=1
 cargo test -p maze_console -- --test-threads=1
 cargo test -p storage -- --test-threads=1
 cargo test -p maze_wasm


### PR DESCRIPTION
Adjust maze_c tests to run on a single thread due to non thread-safe counters used